### PR TITLE
fix: bump to required version 1.9.0 for terraform

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ You need the following permissions to run this module:
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.0 |
 | <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.73.0, < 2.0.0 |
 
 ### Modules

--- a/examples/advanced/version.tf
+++ b/examples/advanced/version.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3.0"
+  required_version = ">= 1.9.0"
 
   # Ensure that there is always 1 example locked into the lowest provider version of the range defined in the main
   # module's version.tf (usually a basic example), and 1 example that will always use the latest provider version.

--- a/examples/basic/version.tf
+++ b/examples/basic/version.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3.0"
+  required_version = ">= 1.9.0"
 
   # Ensure that there is always 1 example locked into the lowest provider version of the range defined in the main
   # module's version.tf (usually a basic example), and 1 example that will always use the latest provider version.

--- a/solutions/fully-configurable/version.tf
+++ b/solutions/fully-configurable/version.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3.0"
+  required_version = ">= 1.9.0"
 
   # Ensure that there is always 1 example locked into the lowest provider version of the range defined in the main
   # module's version.tf (usually a basic example), and 1 example that will always use the latest provider version.

--- a/version.tf
+++ b/version.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3.0"
+  required_version = ">= 1.9.0"
   # If your module requires any terraform providers, uncomment the "required_providers" section below and add all required providers.
   # Each required provider's version should be a flexible range to future proof the module's usage with upcoming minor and patch versions.
 


### PR DESCRIPTION
### Description

update the module and DA version.tf files to require terraform 1.9.0

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
